### PR TITLE
Do not release snapshots when a tag is pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
     script: ./gradlew publish -PgluonNexusUsername=$NEXUS_USERNAME -PgluonNexusPassword=$NEXUS_PASSWORD
     skip_cleanup: true
     on:
-      all_branches: true
+      branch: master
 
   # Deploy releases on every tag push
   - provider: script


### PR DESCRIPTION
`all_branches: true` accepts both branches and tags. Therefore, when a tag was pushed, snapshot deployment was triggered and was failing.