### PR TITLE
Every release should auto-commit next snapshot version

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Release artifacts
+./gradlew publish -PgluonNexusUsername=$NEXUS_USERNAME -PgluonNexusPassword=$NEXUS_PASSWORD -PrepositoryUrl=https://nexus.gluonhq.com/nexus/content/repositories/releases
+
+# Update version by 1
+newVersion=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))
+
+# Replace first occurrence of 
+# version 'TRAVIS_TAG' 
+# with 
+# version 'newVersion-SNAPSHOT'
+sed -i -z "0,/\nversion '$TRAVIS_TAG'/s//\nversion '$newVersion-SNAPSHOT'/" build.gradle
+
+git commit build.gradle -m "Upgrade version to $newVersion-SNAPSHOT" --author "Github Bot <githubbot@gluonhq.com>"
+git push https://gluon-bot:$GITHUB_PASSWORD@github.com/gluonhq/client-gradle-plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ deploy:
 
   # Deploy releases on every tag push
   - provider: script
-    script: ./gradlew publish -PgluonNexusUsername=$NEXUS_USERNAME -PgluonNexusPassword=$NEXUS_PASSWORD -PrepositoryUrl=https://nexus.gluonhq.com/nexus/content/repositories/releases
+    script: sh .ci/release.sh
     skip_cleanup: true
     on:
       tags: true


### PR DESCRIPTION
Given tag version is equal to the version specified in the `build.gradle` file, this change will update the version x.x.x to x.x.x+1 and append SNAPSHOT to it. This file will then be committed back to the repository.

All commits will be done by Github user - [Gluon Bot](https://github.com/gluon-bot).

An environment variable **GITHUB_PASSWORD** needs to be added to TRAVIS.